### PR TITLE
Get refresh_token when calling api_auth in import process as well

### DIFF
--- a/export_trakt.py
+++ b/export_trakt.py
@@ -208,6 +208,10 @@ def api_get_list(options, page):
         else:
             global response_arr
             response_arr += json.loads(r.text)
+        if int(r.headers['X-Pagination-Page-Count']) == 0: 
+            print("No pages found after API call, trakt list may be empty")
+            return response_arr
+        # if 'X-Pagination-Page-Count'in r.headers and r.headers['X-Pagination-Page-Count'] != "0":
         if 'X-Pagination-Page-Count'in r.headers and r.headers['X-Pagination-Page-Count']:
             print("Fetched page {page} of {PageCount} pages for {list} list".format(
                     page=page, PageCount=r.headers['X-Pagination-Page-Count'], list=options.list))

--- a/import_trakt.py
+++ b/import_trakt.py
@@ -171,7 +171,13 @@ def api_auth(options):
         response = request.json()
         _headers['Authorization'] = 'Bearer ' + response["access_token"]
         _headers['trakt-api-key'] = _trakt['client_id']
-        print('Save as "oauth_token" in file {0}: {1}'.format(options.config, response["access_token"]))
+        config = _trakt['config_parser']
+        config.set('TRAKT', 'ACCESS_TOKEN', response["access_token"])
+        config.set('TRAKT', 'REFRESH_TOKEN', response["refresh_token"])
+        with open(options.config, 'w') as configfile:
+            config.write(configfile)
+            print('Saved as "access_token" in file {0}: {1}'.format(options.config, response["access_token"]))
+            print('Saved as "refresh_token" in file {0}: {1}'.format(options.config, response["refresh_token"]))
 
 def api_search_by_id(options, id):
         """API call for Search / ID Lookup / Get ID lookup results"""


### PR DESCRIPTION
Fixed a small oversight where import wasn't recording refresh_token when calling api_auth. Also fixed a bug for exporting from an empty list, which would cause an infinite loop. 