### PR TITLE
fix shows import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.csv
 *.ini
 *.pyc
+
+config/
+.venv

--- a/README.md
+++ b/README.md
@@ -91,18 +91,12 @@ $ python -V
 Python 3.5
 ```
 
-Install need module dependencies, `python3-openssl` and `jq` are optional
+Setup [`venv`](https://docs.python.org/3/library/venv.html) and install dependencies
 
 ```
-$ apt-get install python3-dateutil python3-simplejson python3-requests python3-openssl jq
-```
-
-### On Arch/Manjaro Linux system
-
-Install dependencies with pacman, `python-pyopenssl` and `jq` are optional
-
-```
-$ pacman -S python python-dateutil python-simplejson python-requests python-pyopenssl jq 
+python -m venv .venv
+source .venv/bin/activate
+pip3 install -r requirements.txt
 ```
 
 ### On Windows system
@@ -115,10 +109,12 @@ Ensure you are running Python 3
 Python 3.5
 ```
 
-Install need module dependencies
+Setup [`venv`](https://docs.python.org/3/library/venv.html) and install dependencies
 
 ```
-<python dir>\Scripts\pip3.exe install requests simplejson
+python -m venv .venv
+.venv\Scripts\activate.bat
+pip3 install -r requirements.txt
 ```
 
 ### On macOS system
@@ -146,14 +142,12 @@ $ pip3 install certifi
 
 Open a new Terminal session so that certificates will be available
 
-Install need module dependencies, `pyopenssl` and `jq` are optional
+Setup [`venv`](https://docs.python.org/3/library/venv.html) and install dependencies
 
-```shell
-$ pip3 install python-dateutil
-$ pip3 install simplejson
-$ pip3 install requests
-$ pip3 install pyopenssl
-$ pip3 install jq
+```
+python -m venv .venv
+source .venv/bin/activate
+pip3 install -r requirements.txt
 ```
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+python-dateutil
+simplejson
+requests


### PR DESCRIPTION
Trakt sync api returns `episodes` field even when sync is for whole shows.

This makes using `options.type` as key in `result['added']` dict impossible, since result won't have this key.

To solve this issue, I'm using `Counter` object (instead of standard dict), which sums `added` and `updated`.

For `not_found` I decided that it would make sense to aggregate data instead of only showing counter (since it should be useful to know what wasn't imported).