### PR TITLE
Add title-based lookup for movies and TV shows if ID is not provided

### DIFF
--- a/import.md
+++ b/import.md
@@ -96,23 +96,27 @@ Import all episodes with tvshows imdbid from file ``episodes_views.csv`` into hi
 
 #### Movies to add watchlist
 Header line as format must be one 'imdb' or 'tmdb' or 'tvdb' or 'tvrage' or 'trakt'
-Other colums are ignored
-One 'imdb' or 'tmdb' or 'tvdb' or 'tvrage' or 'trakt' by line
+If the ID is not available in the specified format, the system will automatically search Trakt.tv's database using the value in the 'title' field to find the correct ID
+Other columns are ignored
 ```
-imdb
-tt22239XX
-tt11712XX
-tt12728XX
+imdb,title
+tt22239XX,
+tt11712XX,
+tt12728XX,
+,The Matrix
+,Inception
 ```
 
 #### TVShows to add to watchlist
 Header line as format must be one 'imdb' or 'tmdb' or 'tvdb' or 'tvrage' or 'trakt'
-Other colums are ignored
-One 'imdb' or 'tmdb' or 'tvdb' or 'tvrage' or 'trakt' by line
+If the ID is not available in the specified format, the system will automatically search Trakt.tv's database using the value in the 'title' field to find the correct ID
+Other columns are ignored
 ```
-imdb
-tt04606XX
-tt12365XX
+imdb,title
+tt04606XX,
+tt12365XX,
+,Breaking Bad
+,The Wire
 ```
 
 #### Episodes as views to history


### PR DESCRIPTION
This PR adds the ability to import movies and TV shows using titles when IDs are not available.

**Key changes:**

- Added `get_imdb_id_by_title() `function to search Trakt.tv's API for correct IDs
- Modified the import logic to handle both ID and title-based lookups
- Updated documentation to reflect the new title lookup feature
- Enhanced CSV format to support both ID and title columns

**Use case:**

- Users can now import their media using just titles in their CSV files
- The system will automatically search Trakt.tv to find the corresponding ID
- Supports both movies and TV shows
- Maintains backwards compatibility with ID-based imports
